### PR TITLE
Upgrading benchmarks to lamellar 0.7.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-/target
+*/target
 **/*.rs.bk
 Cargo.lock
 

--- a/histo/Cargo.toml
+++ b/histo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "histo"
-version = "0.4.1"
+version = "0.5.0"
 authors = ["Ryan D. Friese"]
 edition = "2021"
 
@@ -8,7 +8,7 @@ edition = "2021"
 serde = { version = "1.0", features = ["derive"] }
 lazy_static = "1.3.0"
 rand = "0.6"
-lamellar = { version = "0.5.0"} #add features = ["enable-rofi"] to use rofi lamellae
+lamellar = { version = "0.7.1"} #add features = ["enable-rofi"] to use rofi lamellae
 parking_lot = { version = "0.12" }
 tracing = "0.1"
 tracing-futures = "0.2"

--- a/histo/Cargo.toml
+++ b/histo/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "histo"
-version = "0.5.0"
-authors = ["Ryan D. Friese"]
+version = "0.7.0"
+authors = ["Ryan D. Friese", "Joseph A. Cottam"]
 edition = "2021"
 
 [dependencies]

--- a/histo/README.md
+++ b/histo/README.md
@@ -24,12 +24,6 @@ These benchmarks requires the following dependencies:
 
 * Crates listed in Cargo.toml
 
-At the time of release, Lamellar has been tested with the following external packages:
-
-| **GCC** | **CLANG** | **ROFI**  | **OFI**   | **IB VERBS**  | **MPI**       | **SLURM** | **LAMELLAR** |
-|--------:|----------:|----------:|----------:|--------------:|--------------:|----------:|-------------:|
-| 7.1.0   | 8.0.1     | 0.1.0     | 1.9.0     | 1.13          | mvapich2/2.3a | 17.02.7   | 0.2.1        |
-
 The OFI_DIR environment variable must be specified with the location of the OFI installation.
 The ROFI_DIR environment variable must be specified with the location of the ROFI installation.
 
@@ -63,23 +57,20 @@ TESTING
 
 The benchmarks are designed to be run with on multiple compute nodes (1 node is valid). Here is a simple proceedure to run the tests that assume a compute cluster and [SLURM](https://slurm.schedmd.com) job manager. Please, refer to the job manager documentaiton for details on how to run command on different clusters. Lamellar grabs job information (size, distribution, etc.) from the jbo manager and runtime launcher (e.g., MPI, please refer to the BUILING REQUIREMENTS section for a list of tested software versions).
 
-1. Allocates two compute nodes on the cluster:
+To run the benchmark through the slurm queue, first compile with `cargo build --release` then run one of the following:
+- `srun -N 2 target/release/histo_buffered_safe_am`
+- `srun -N 2 target/release/histo_buffered_unsafe_am`
+- `srun -N 2 target/release/histo_darc`
+- `srun -N 2 target/release/histo_lamellar_array_comparison`
+- `srun -N 2 target/release/histo_safe_am`
+- `srun -N 2 target/release/histo_unsafe_am`
 
-`salloc -N 2 -p compute`
-
-2. Run histo(_static) using `mpiexec` launcher.
-
-`mpiexec -n 2 ./target/release/histo_(static) 10000000`  (argument = number of updates to perform)
-
-3. Run histo_buffered_updates(_static)
-
-`mpiexec -n 2 ./target/release/histo_buffered_updates(_static) 10000000 100`  (argument = number of updates to perform, number of updates to buffer)
-
-Note that if using the "local" lamellae, simply execute the binary directly
+*Note:* If using the "local" lamellae, simply execute the binary directly
 
 HISTORY
 -------
-
+- version 0.7:
+ - Update to match Lamellar 0.7.1 api
 - version 0.2:
   - update to match Lamellar v0.2 api
   - implement registered AM version

--- a/histo/src/histo_buffered_safe_am.rs
+++ b/histo/src/histo_buffered_safe_am.rs
@@ -42,6 +42,7 @@ struct LaunchAm {
 #[lamellar::local_am]
 impl LamellarAM for LaunchAm {
     async fn exec(self) {
+        // TOOD: Should tasks be queued and await all at the end instead?
         // let now = Instant::now();
         let num_pes = lamellar::num_pes;
         let mut buffs: std::vec::Vec<std::vec::Vec<usize>> =
@@ -61,8 +62,7 @@ impl LamellarAM for LaunchAm {
                             buff: buff,
                             counts: self.counts.clone(),
                         },
-                    )
-                    .block();
+                    ).await;
                 buffs[rank].clear();
             }
         }
@@ -77,8 +77,7 @@ impl LamellarAM for LaunchAm {
                             buff: buff,
                             counts: self.counts.clone(),
                         },
-                    )
-                    .block();
+                    ).await;
             }
         }
     }

--- a/histo/src/histo_buffered_safe_am.rs
+++ b/histo/src/histo_buffered_safe_am.rs
@@ -42,7 +42,6 @@ struct LaunchAm {
 #[lamellar::local_am]
 impl LamellarAM for LaunchAm {
     async fn exec(self) {
-        // TOOD: Should tasks be queued and await all at the end instead?
         // let now = Instant::now();
         let num_pes = lamellar::num_pes;
         let mut buffs: std::vec::Vec<std::vec::Vec<usize>> =
@@ -55,14 +54,14 @@ impl LamellarAM for LaunchAm {
             buffs[rank].push(offset);
             if buffs[rank].len() >= self.buffer_amt {
                 let buff = buffs[rank].clone();
-                task_group
+                let _ = task_group
                     .exec_am_pe(
                         rank,
                         HistoBufferedAM {
                             buff: buff,
                             counts: self.counts.clone(),
                         },
-                    ).await;
+                    ).spawn();
                 buffs[rank].clear();
             }
         }
@@ -70,16 +69,18 @@ impl LamellarAM for LaunchAm {
         for rank in 0..num_pes {
             let buff = buffs[rank].clone();
             if buff.len() > 0 {
-                task_group
+                let _ = task_group
                     .exec_am_pe(
                         rank,
                         HistoBufferedAM {
                             buff: buff,
                             counts: self.counts.clone(),
                         },
-                    ).await;
+                    ).spawn();
             }
         }
+
+        task_group.await_all().await;
     }
 }
 
@@ -113,7 +114,7 @@ fn main() {
     let world = lamellar::LamellarWorldBuilder::new().build();
     let my_pe = world.my_pe();
     let num_pes = world.num_pes();
-    let counts = world.alloc_shared_mem_region(COUNTS_LOCAL_LEN).block();
+    let counts = world.alloc_shared_mem_region(COUNTS_LOCAL_LEN);
     let global_count = COUNTS_LOCAL_LEN * num_pes;
     let l_num_updates = args
         .get(1)
@@ -140,6 +141,7 @@ fn main() {
 
     let rand_index = world.alloc_one_sided_mem_region(l_num_updates);
     let mut rng: StdRng = SeedableRng::seed_from_u64(my_pe as u64);
+    let counts = counts.block();
 
     unsafe {
         for elem in counts.as_mut_slice().unwrap().iter_mut() {

--- a/histo/src/histo_buffered_safe_am.rs
+++ b/histo/src/histo_buffered_safe_am.rs
@@ -61,7 +61,8 @@ impl LamellarAM for LaunchAm {
                             buff: buff,
                             counts: self.counts.clone(),
                         },
-                    ).spawn();
+                    )
+                    .spawn();
                 buffs[rank].clear();
             }
         }
@@ -76,7 +77,8 @@ impl LamellarAM for LaunchAm {
                             buff: buff,
                             counts: self.counts.clone(),
                         },
-                    ).spawn();
+                    )
+                    .spawn();
             }
         }
 

--- a/histo/src/histo_buffered_safe_am.rs
+++ b/histo/src/histo_buffered_safe_am.rs
@@ -121,12 +121,12 @@ fn main() {
     let l_num_updates = args
         .get(1)
         .and_then(|s| s.parse::<usize>().ok())
-        .unwrap_or_else(|| 1000);
+        .unwrap_or(1000);
 
     let buffer_amt = args
         .get(2)
         .and_then(|s| s.parse::<usize>().ok())
-        .unwrap_or_else(|| 1000);
+        .unwrap_or(1000);
     let num_threads = args
         .get(3)
         .and_then(|s| s.parse::<usize>().ok())

--- a/histo/src/histo_buffered_unsafe_am.rs
+++ b/histo/src/histo_buffered_unsafe_am.rs
@@ -51,7 +51,8 @@ impl LamellarAM for LaunchAm {
                             buff: buff,
                             counts: self.counts.clone(),
                         },
-                    ).spawn();
+                    )
+                    .spawn();
                 buffs[rank].clear();
             }
         }
@@ -66,7 +67,8 @@ impl LamellarAM for LaunchAm {
                             buff: buff,
                             counts: self.counts.clone(),
                         },
-                    ).spawn();
+                    )
+                    .spawn();
             }
         }
 
@@ -131,8 +133,8 @@ fn main() {
 
     let rand_index = world.alloc_one_sided_mem_region(l_num_updates);
     let mut rng: StdRng = SeedableRng::seed_from_u64(my_pe as u64);
-    let counts =counts.block();
-    
+    let counts = counts.block();
+
     unsafe {
         for elem in counts.as_mut_slice().unwrap().iter_mut() {
             *elem = 0;

--- a/histo/src/histo_buffered_unsafe_am.rs
+++ b/histo/src/histo_buffered_unsafe_am.rs
@@ -111,12 +111,12 @@ fn main() {
     let l_num_updates = args
         .get(1)
         .and_then(|s| s.parse::<usize>().ok())
-        .unwrap_or_else(|| 1000);
+        .unwrap_or(1000);
 
     let buffer_amt = args
         .get(2)
         .and_then(|s| s.parse::<usize>().ok())
-        .unwrap_or_else(|| 1000);
+        .unwrap_or(1000);
     let num_threads = args
         .get(3)
         .and_then(|s| s.parse::<usize>().ok())

--- a/histo/src/histo_darc.rs
+++ b/histo/src/histo_darc.rs
@@ -80,7 +80,7 @@ fn main() {
     let l_num_updates = args
         .get(1)
         .and_then(|s| s.parse::<usize>().ok())
-        .unwrap_or_else(|| 1000);
+        .unwrap_or(1000);
 
     let mut counts_data = Vec::with_capacity(COUNTS_LOCAL_LEN);
     for _ in 0..COUNTS_LOCAL_LEN {

--- a/histo/src/histo_darc.rs
+++ b/histo/src/histo_darc.rs
@@ -42,7 +42,8 @@ impl LamellarAM for LaunchAm {
                         offset: offset,
                         counts: self.counts.clone(),
                     },
-                ).spawn();
+                )
+                .spawn();
         }
     }
 }

--- a/histo/src/histo_darc.rs
+++ b/histo/src/histo_darc.rs
@@ -35,15 +35,14 @@ impl LamellarAM for LaunchAm {
         for idx in &self.rand_index {
             let rank = idx % lamellar::num_pes;
             let offset = idx / lamellar::num_pes;
-            lamellar::world
+            let _ = lamellar::world
                 .exec_am_pe(
                     rank,
                     HistoAM {
                         offset: offset,
                         counts: self.counts.clone(),
                     },
-                )
-                .await;
+                ).spawn();
         }
     }
 }

--- a/histo/src/histo_darc.rs
+++ b/histo/src/histo_darc.rs
@@ -35,13 +35,15 @@ impl LamellarAM for LaunchAm {
         for idx in &self.rand_index {
             let rank = idx % lamellar::num_pes;
             let offset = idx / lamellar::num_pes;
-            lamellar::world.exec_am_pe(
-                rank,
-                HistoAM {
-                    offset: offset,
-                    counts: self.counts.clone(),
-                },
-            );
+            lamellar::world
+                .exec_am_pe(
+                    rank,
+                    HistoAM {
+                        offset: offset,
+                        counts: self.counts.clone(),
+                    },
+                )
+                .await;
         }
     }
 }
@@ -84,7 +86,9 @@ fn main() {
     for _ in 0..COUNTS_LOCAL_LEN {
         counts_data.push(AtomicUsize::new(0));
     }
-    let counts = Darc::new(&world, counts_data).expect("unable to create darc");
+    let counts = Darc::new(&world, counts_data)
+        .block()
+        .expect("unable to create darc");
     let mut rng: StdRng = SeedableRng::seed_from_u64(my_pe as u64);
     let rand_index = (0..l_num_updates)
         .into_iter()

--- a/histo/src/histo_lamellar_array_comparison.rs
+++ b/histo/src/histo_lamellar_array_comparison.rs
@@ -21,7 +21,7 @@ fn histo<T: ElementArithmeticOps + std::fmt::Debug>(
     let now = Instant::now();
 
     //the actual histo
-    counts.batch_add(rand_index.local_data(), one).block(); //TODO: Consider making histo 'async' and changing to 'await'
+    let _ = counts.batch_add(rand_index.local_data(), one).spawn();
 
     //-----------------
     if my_pe == 0 {
@@ -71,19 +71,21 @@ fn main() {
         world.team(),
         global_count,
         lamellar::array::Distribution::Cyclic,
-    )
-    .block();
+    );
     let rand_index = UnsafeArray::<usize>::new(
         world.team(),
         l_num_updates * num_pes,
         lamellar::array::Distribution::Block,
-    )
-    .block();
+    );
+    
     let rng: Arc<Mutex<StdRng>> = Arc::new(Mutex::new(SeedableRng::seed_from_u64(my_pe as u64)));
+    let counts = counts.block();
 
     // initialize arrays
     let counts_init = unsafe { counts.dist_iter_mut().for_each(|x| *x = 0) };
     // rand_index.dist_iter_mut().for_each(move |x| *x = rng.lock().gen_range(0,global_count)).wait(); //this is slow because of the lock on the rng so we will do unsafe slice version instead...
+    let rand_index = rand_index.block();
+    
     unsafe {
         let mut rng = rng.lock();
         for elem in rand_index.local_as_mut_slice().iter_mut() {

--- a/histo/src/histo_lamellar_array_comparison.rs
+++ b/histo/src/histo_lamellar_array_comparison.rs
@@ -77,7 +77,7 @@ fn main() {
         l_num_updates * num_pes,
         lamellar::array::Distribution::Block,
     );
-    
+
     let rng: Arc<Mutex<StdRng>> = Arc::new(Mutex::new(SeedableRng::seed_from_u64(my_pe as u64)));
     let counts = counts.block();
 
@@ -85,7 +85,7 @@ fn main() {
     let counts_init = unsafe { counts.dist_iter_mut().for_each(|x| *x = 0) };
     // rand_index.dist_iter_mut().for_each(move |x| *x = rng.lock().gen_range(0,global_count)).wait(); //this is slow because of the lock on the rng so we will do unsafe slice version instead...
     let rand_index = rand_index.block();
-    
+
     unsafe {
         let mut rng = rng.lock();
         for elem in rand_index.local_as_mut_slice().iter_mut() {

--- a/histo/src/histo_lamellar_array_comparison.rs
+++ b/histo/src/histo_lamellar_array_comparison.rs
@@ -65,7 +65,7 @@ fn main() {
     let l_num_updates = args
         .get(1)
         .and_then(|s| s.parse::<usize>().ok())
-        .unwrap_or_else(|| 1000);
+        .unwrap_or(1000);
 
     let counts = UnsafeArray::<usize>::new(
         world.team(),

--- a/histo/src/histo_lamellar_array_comparison.rs
+++ b/histo/src/histo_lamellar_array_comparison.rs
@@ -21,7 +21,7 @@ fn histo<T: ElementArithmeticOps + std::fmt::Debug>(
     let now = Instant::now();
 
     //the actual histo
-    counts.batch_add(rand_index.local_data(), one);
+    counts.batch_add(rand_index.local_data(), one).block(); //TODO: Consider making histo 'async' and changing to 'await'
 
     //-----------------
     if my_pe == 0 {
@@ -50,7 +50,7 @@ fn histo<T: ElementArithmeticOps + std::fmt::Debug>(
             array_type
         );
     }
-    println!("pe {:?} sum {:?}", my_pe, world.block_on(counts.sum()));
+    // println!("pe {:?} sum {:?}", my_pe, world.block_on(counts.as_slice().iter().sum()));
     counts.barrier();
     world.MB_sent()
 }
@@ -67,13 +67,22 @@ fn main() {
         .and_then(|s| s.parse::<usize>().ok())
         .unwrap_or_else(|| 1000);
 
-    let counts = UnsafeArray::<usize>::new(world.team(), global_count, lamellar::array::Distribution::Cyclic);
-    let rand_index =
-        UnsafeArray::<usize>::new(world.team(), l_num_updates * num_pes, lamellar::array::Distribution::Block);
+    let counts = UnsafeArray::<usize>::new(
+        world.team(),
+        global_count,
+        lamellar::array::Distribution::Cyclic,
+    )
+    .block();
+    let rand_index = UnsafeArray::<usize>::new(
+        world.team(),
+        l_num_updates * num_pes,
+        lamellar::array::Distribution::Block,
+    )
+    .block();
     let rng: Arc<Mutex<StdRng>> = Arc::new(Mutex::new(SeedableRng::seed_from_u64(my_pe as u64)));
 
     // initialize arrays
-    let counts_init = unsafe{counts.dist_iter_mut().for_each(|x| *x = 0)};
+    let counts_init = unsafe { counts.dist_iter_mut().for_each(|x| *x = 0) };
     // rand_index.dist_iter_mut().for_each(move |x| *x = rng.lock().gen_range(0,global_count)).wait(); //this is slow because of the lock on the rng so we will do unsafe slice version instead...
     unsafe {
         let mut rng = rng.lock();
@@ -84,7 +93,7 @@ fn main() {
     world.block_on(counts_init);
     //counts.wait_all(); equivalent in this case to the above statement
 
-    let rand_index = rand_index.into_read_only();
+    let rand_index = rand_index.into_read_only().block();
     world.barrier();
 
     if my_pe == 0 {
@@ -101,10 +110,10 @@ fn main() {
         1,
         0.0,
     );
-    world.block_on(unsafe{counts.dist_iter_mut().for_each(|x| *x = 0)});
+    world.block_on(unsafe { counts.dist_iter_mut().for_each(|x| *x = 0) });
     counts.barrier();
 
-    let counts = counts.into_local_lock();
+    let counts = counts.into_local_lock().block();
     if my_pe == 0 {
         println!("local lock atomic histo");
     }
@@ -122,7 +131,7 @@ fn main() {
     world.block_on(counts.dist_iter_mut().for_each(|x| *x = 0));
     counts.barrier();
 
-    let counts = counts.into_atomic();
+    let counts = counts.into_atomic().block();
     if my_pe == 0 {
         println!("atomic histo");
     }

--- a/histo/src/histo_lamellar_atomicarray.rs
+++ b/histo/src/histo_lamellar_atomicarray.rs
@@ -9,7 +9,7 @@ use std::time::Instant;
 //===== HISTO BEGIN ======
 
 fn histo(counts: &AtomicArray<usize>, rand_index: &ReadOnlyArray<usize>) {
-    counts.batch_add(rand_index.local_data(), 1).block();
+    let _ = counts.batch_add(rand_index.local_data(), 1).spawn();
 }
 
 //===== HISTO END ======
@@ -37,19 +37,22 @@ fn main() {
         world.team(),
         global_count,
         lamellar::array::Distribution::Cyclic,
-    )
-    .block();
+    );
+
     let rand_index = UnsafeArray::<usize>::new(
         world.team(),
         l_num_updates * num_pes,
         lamellar::array::Distribution::Block,
-    )
-    .block();
+    );
     let rng: Arc<Mutex<StdRng>> = Arc::new(Mutex::new(SeedableRng::seed_from_u64(my_pe as u64)));
+
+    let unsafe_counts = unsafe_counts.block();
 
     // initialize arrays
     let counts_init = unsafe { unsafe_counts.dist_iter_mut().for_each(|x| *x = 0) };
     // rand_index.dist_iter_mut().for_each(move |x| *x = rng.lock().gen_range(0,global_count)).wait(); //this is slow because of the lock on the rng so we will do unsafe slice version instead...
+
+    let rand_index = rand_index.block();
     unsafe {
         let mut rng = rng.lock();
         for elem in rand_index.local_as_mut_slice().iter_mut() {

--- a/histo/src/histo_lamellar_atomicarray.rs
+++ b/histo/src/histo_lamellar_atomicarray.rs
@@ -25,7 +25,7 @@ fn main() {
     let l_num_updates = args
         .get(1)
         .and_then(|s| s.parse::<usize>().ok())
-        .unwrap_or_else(|| 1000);
+        .unwrap_or(1000);
 
     if my_pe == 0 {
         println!("updates total {}", l_num_updates * num_pes);

--- a/histo/src/histo_safe_am.rs
+++ b/histo/src/histo_safe_am.rs
@@ -87,7 +87,7 @@ fn main() {
     let l_num_updates = args
         .get(1)
         .and_then(|s| s.parse::<usize>().ok())
-        .unwrap_or_else(|| 1000);
+        .unwrap_or(1000);
     let num_threads = args
         .get(2)
         .and_then(|s| s.parse::<usize>().ok())

--- a/histo/src/histo_safe_am.rs
+++ b/histo/src/histo_safe_am.rs
@@ -96,9 +96,11 @@ fn main() {
             Err(_) => 1,
         });
 
-    let counts = world.alloc_shared_mem_region(COUNTS_LOCAL_LEN).block();
+    let counts = world.alloc_shared_mem_region(COUNTS_LOCAL_LEN);
     let rand_index = world.alloc_one_sided_mem_region(l_num_updates);
     let mut rng: StdRng = SeedableRng::seed_from_u64(my_pe as u64);
+
+    let counts = counts.block();
     //initialize arrays
     unsafe {
         for elem in counts.as_mut_slice().unwrap().iter_mut() {

--- a/histo/src/histo_unsafe_am.rs
+++ b/histo/src/histo_unsafe_am.rs
@@ -89,9 +89,10 @@ fn main() {
             Err(_) => 1,
         });
 
-    let counts = world.alloc_shared_mem_region(COUNTS_LOCAL_LEN).block();
+    let counts = world.alloc_shared_mem_region(COUNTS_LOCAL_LEN);
     let rand_index = world.alloc_one_sided_mem_region(l_num_updates);
     let mut rng: StdRng = SeedableRng::seed_from_u64(my_pe as u64);
+    let counts = counts.block();
     //initialize arrays
     unsafe {
         for elem in counts.as_mut_slice().unwrap().iter_mut() {

--- a/histo/src/histo_unsafe_am.rs
+++ b/histo/src/histo_unsafe_am.rs
@@ -79,7 +79,7 @@ fn main() {
     let l_num_updates = args
         .get(1)
         .and_then(|s| s.parse::<usize>().ok())
-        .unwrap_or_else(|| 1000);
+        .unwrap_or(1000);
 
     let num_threads = args
         .get(2)

--- a/histo/src/histo_unsafe_am.rs
+++ b/histo/src/histo_unsafe_am.rs
@@ -31,16 +31,18 @@ struct LaunchAm {
 #[lamellar::local_am]
 impl LamellarAM for LaunchAm {
     async fn exec(self) {
-        for idx in unsafe {self.rand_index.as_slice().unwrap()} {
+        for idx in unsafe { self.rand_index.as_slice().unwrap() } {
             let rank = idx % lamellar::num_pes;
             let offset = idx / lamellar::num_pes;
-            lamellar::world.exec_am_pe(
-                rank,
-                HistoAM {
-                    offset: offset,
-                    counts: self.counts.clone(),
-                },
-            );
+            lamellar::world
+                .exec_am_pe(
+                    rank,
+                    HistoAM {
+                        offset: offset,
+                        counts: self.counts.clone(),
+                    },
+                )
+                .await;
         }
     }
 }
@@ -87,7 +89,7 @@ fn main() {
             Err(_) => 1,
         });
 
-    let counts = world.alloc_shared_mem_region(COUNTS_LOCAL_LEN);
+    let counts = world.alloc_shared_mem_region(COUNTS_LOCAL_LEN).block();
     let rand_index = world.alloc_one_sided_mem_region(l_num_updates);
     let mut rng: StdRng = SeedableRng::seed_from_u64(my_pe as u64);
     //initialize arrays
@@ -143,9 +145,7 @@ fn main() {
         );
     }
 
-    println!(
-        "pe {:?} sum {:?}",
-        my_pe,
-        unsafe{counts.as_slice().unwrap().iter().sum::<usize>()}
-    );
+    println!("pe {:?} sum {:?}", my_pe, unsafe {
+        counts.as_slice().unwrap().iter().sum::<usize>()
+    });
 }

--- a/index_gather/Cargo.toml
+++ b/index_gather/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "index_gather"
-version = "0.4.1"
+version = "0.5.0"
 authors = ["Ryan D. Friese"]
 edition = "2021"
 
@@ -8,7 +8,7 @@ edition = "2021"
 serde = { version = "1.0", features = ["derive"] }
 lazy_static = "1.3.0"
 rand = "0.6"
-lamellar = { version = "0.5.0"} #add features = ["enable-rofi"] to use rofi lamellae
+lamellar = { version = "0.7.1"} #add features = ["enable-rofi"] to use rofi lamellae
 parking_lot = { version = "0.12" }
 
 [profile.release]

--- a/index_gather/Cargo.toml
+++ b/index_gather/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "index_gather"
-version = "0.5.0"
-authors = ["Ryan D. Friese"]
+version = "0.7.0"
+authors = ["Ryan D. Friese", "Joseph A. Cottam"]
 edition = "2021"
 
 [dependencies]

--- a/index_gather/README.md
+++ b/index_gather/README.md
@@ -22,12 +22,6 @@ These benchmarks requires the following dependencies:
 
 * Crates listed in Cargo.toml
 
-At the time of release, Lamellar has been tested with the following external packages:
-
-| **GCC** | **CLANG** | **ROFI**  | **OFI**   | **IB VERBS**  | **MPI**       | **SLURM** |
-|--------:|----------:|----------:|----------:|--------------:|--------------:|----------:|
-| 7.1.0   | 8.0.1     | 0.1.0     | 1.9.0     | 1.13          | mvapich2/2.3a | 17.02.7   |
-
 The OFI_DIR environment variable must be specified with the location of the OFI installation.
 The ROFI_DIR environment variable must be specified with the location of the ROFI installation.
 
@@ -60,19 +54,12 @@ TESTING
 
 The benchmarks are designed to be run with on multiple compute nodes (1 node is valid). Here is a simple proceedure to run the tests that assume a compute cluster and [SLURM](https://slurm.schedmd.com) job manager. Please, refer to the job manager documentaiton for details on how to run command on different clusters. Lamellar grabs job information (size, distribution, etc.) from the jbo manager and runtime launcher (e.g., MPI, please refer to the BUILING REQUIREMENTS section for a list of tested software versions).
 
-1. Allocates two compute nodes on the cluster:
+To run the benchmark through the slurm queue, first compile with `cargo build --release` then run one of the following:
+- `srun -N 2 target/release/index_gather_atomic_array`
+- `srun -N 2 target/release/index_gather_buffered_am`
+- `srun -N 2 target/release/index_gather_read_only_array`
 
-`salloc -N 2 -p compute`
-
-2. Run histo(_static) using `mpiexec` launcher.
-
-`mpiexec -n 2 ./target/release/index_gather_atomic_array 10000000`  (argument = number of updates to perform)
-
-3. Run histo_buffered_updates(_static)
-
-`mpiexec -n 2 ./target/release/index_gather_atomic_array 10000000 100`  (argument = number of updates to perform, number of updates to buffer)
-
-Note that if using the "local" lamellae, simply execute the binary directly
+*Note:* If using the "local" lamellae, simply execute the binary directly
 
 
 HISTORY

--- a/index_gather/README.md
+++ b/index_gather/README.md
@@ -24,9 +24,9 @@ These benchmarks requires the following dependencies:
 
 At the time of release, Lamellar has been tested with the following external packages:
 
-| **GCC** | **CLANG** | **ROFI**  | **OFI**   | **IB VERBS**  | **MPI**       | **SLURM** | **LAMELLAR** |
-|--------:|----------:|----------:|----------:|--------------:|--------------:|----------:|-------------:|
-| 7.1.0   | 8.0.1     | 0.1.0     | 1.9.0     | 1.13          | mvapich2/2.3a | 17.02.7   | 0.2.1        |
+| **GCC** | **CLANG** | **ROFI**  | **OFI**   | **IB VERBS**  | **MPI**       | **SLURM** |
+|--------:|----------:|----------:|----------:|--------------:|--------------:|----------:|
+| 7.1.0   | 8.0.1     | 0.1.0     | 1.9.0     | 1.13          | mvapich2/2.3a | 17.02.7   |
 
 The OFI_DIR environment variable must be specified with the location of the OFI installation.
 The ROFI_DIR environment variable must be specified with the location of the ROFI installation.

--- a/index_gather/src/index_gather_atomic_array.rs
+++ b/index_gather/src/index_gather_atomic_array.rs
@@ -4,12 +4,12 @@ use rand::prelude::*;
 use std::time::Instant;
 
 fn index_gather(array: &AtomicArray<usize>, rand_index: OneSidedMemoryRegion<usize>) {
-    let rand_slice = unsafe {rand_index.as_slice().expect("PE on world team")}; // Safe as we are the only consumer of this mem region
+    let rand_slice = unsafe { rand_index.as_slice().expect("PE on world team") }; // Safe as we are the only consumer of this mem region
     array.batch_load(rand_slice).block();
 }
 
 const COUNTS_LOCAL_LEN: usize = 1000000; //this will be 800MBB on each pe
-                                             // srun -N <num nodes> target/release/histo_lamellar_array <num updates>
+                                         // srun -N <num nodes> target/release/histo_lamellar_array <num updates>
 fn main() {
     let args: Vec<String> = std::env::args().collect();
     let world = lamellar::LamellarWorldBuilder::new().build();
@@ -21,23 +21,30 @@ fn main() {
         .and_then(|s| s.parse::<usize>().ok())
         .unwrap_or_else(|| 1000);
 
-        if my_pe == 0 {
-            println!("updates total {}", l_num_updates * num_pes);
-            println!("updates per pe {}", l_num_updates);
-            println!("table size per pe{}", COUNTS_LOCAL_LEN);
-        }
+    if my_pe == 0 {
+        println!("updates total {}", l_num_updates * num_pes);
+        println!("updates per pe {}", l_num_updates);
+        println!("table size per pe{}", COUNTS_LOCAL_LEN);
+    }
 
-    let unsafe_array = UnsafeArray::<usize>::new(world.team(), global_count, lamellar::array::Distribution::Cyclic).block();
+    let unsafe_array = UnsafeArray::<usize>::new(
+        world.team(),
+        global_count,
+        lamellar::array::Distribution::Cyclic,
+    )
+    .block();
     // let rand_index =
     //     UnsafeArray::<usize>::new(world.team(), l_num_updates * num_pes, Distribution::Block);
     let rand_index = world.alloc_one_sided_mem_region(l_num_updates);
     let mut rng: StdRng = SeedableRng::seed_from_u64(my_pe as u64);
 
     // initialize arrays
-    let array_init = unsafe {unsafe_array
-        .dist_iter_mut()
-        .enumerate()
-        .for_each(|(i, x)| *x = i)};
+    let array_init = unsafe {
+        unsafe_array
+            .dist_iter_mut()
+            .enumerate()
+            .for_each(|(i, x)| *x = i)
+    };
     // rand_index.dist_iter_mut().for_each(move |x| *x = rng.lock().gen_range(0,global_count)).wait(); //this is slow because of the lock on the rng so we will do unsafe slice version instead...
     unsafe {
         for elem in rand_index.as_mut_slice().unwrap().iter_mut() {
@@ -80,10 +87,7 @@ fn main() {
             "MUPS: {:?}",
             ((l_num_updates * num_pes) as f64 / 1_000_000.0) / global_time,
         );
-        println!(
-            "Secs: {:?}",
-             global_time,
-        );
+        println!("Secs: {:?}", global_time,);
         println!(
             "GB/s Injection rate: {:?}",
             (8.0 * (l_num_updates * 2) as f64 * 1.0E-9) / global_time,

--- a/index_gather/src/index_gather_atomic_array.rs
+++ b/index_gather/src/index_gather_atomic_array.rs
@@ -19,7 +19,7 @@ fn main() {
     let l_num_updates = args
         .get(1)
         .and_then(|s| s.parse::<usize>().ok())
-        .unwrap_or_else(|| 1000);
+        .unwrap_or(1000);
 
     if my_pe == 0 {
         println!("updates total {}", l_num_updates * num_pes);

--- a/index_gather/src/index_gather_buffered_am.rs
+++ b/index_gather/src/index_gather_buffered_am.rs
@@ -5,8 +5,8 @@ use rand::prelude::*;
 use std::future::Future;
 use std::time::Instant;
 
-const COUNTS_LOCAL_LEN: usize =  1000000;//100_000_000; //this will be 800MB on each pe
-//===== HISTO BEGIN ======
+const COUNTS_LOCAL_LEN: usize = 1000000; //100_000_000; //this will be 800MB on each pe
+                                         //===== HISTO BEGIN ======
 
 #[lamellar::AmData(Clone, Debug)]
 struct IndexGatherBufferedAM {
@@ -16,9 +16,12 @@ struct IndexGatherBufferedAM {
 
 #[lamellar::am]
 impl LamellarAM for IndexGatherBufferedAM {
-    async fn exec(self) -> Vec<usize>{
-        let counts_slice = unsafe {self.counts.as_slice().unwrap()};
-        self.buff.iter().map(|i| counts_slice[*i]).collect::<Vec<usize>>()
+    async fn exec(self) -> Vec<usize> {
+        let counts_slice = unsafe { self.counts.as_slice().unwrap() };
+        self.buff
+            .iter()
+            .map(|i| counts_slice[*i])
+            .collect::<Vec<usize>>()
     }
 }
 
@@ -36,20 +39,22 @@ impl LamellarAM for LaunchAm {
         let mut buffs: std::vec::Vec<std::vec::Vec<usize>> =
             vec![Vec::with_capacity(self.buffer_amt); num_pes];
         let task_group = LamellarTaskGroup::new(lamellar::team.clone());
-        for idx in unsafe {self.rand_index.as_slice().unwrap()} {
+        for idx in unsafe { self.rand_index.as_slice().unwrap() } {
             let rank = idx % num_pes;
             let offset = idx / num_pes;
 
             buffs[rank].push(offset);
             if buffs[rank].len() >= self.buffer_amt {
                 let buff = buffs[rank].clone();
-                task_group.exec_am_pe(
-                    rank,
-                    IndexGatherBufferedAM {
-                        buff: buff,
-                        counts: self.counts.clone(),
-                    },
-                ).await;
+                task_group
+                    .exec_am_pe(
+                        rank,
+                        IndexGatherBufferedAM {
+                            buff: buff,
+                            counts: self.counts.clone(),
+                        },
+                    )
+                    .await;
                 buffs[rank].clear();
             }
         }
@@ -57,13 +62,15 @@ impl LamellarAM for LaunchAm {
         for rank in 0..num_pes {
             let buff = buffs[rank].clone();
             if buff.len() > 0 {
-                task_group.exec_am_pe(
-                    rank,
-                    IndexGatherBufferedAM {
-                        buff: buff,
-                        counts: self.counts.clone(),
-                    },
-                ).await;
+                task_group
+                    .exec_am_pe(
+                        rank,
+                        IndexGatherBufferedAM {
+                            buff: buff,
+                            counts: self.counts.clone(),
+                        },
+                    )
+                    .await;
             }
         }
     }
@@ -118,11 +125,11 @@ fn main() {
             Err(_) => 1,
         });
 
-        if my_pe == 0 {
-            println!("updates total {}", l_num_updates * num_pes);
-            println!("updates per pe {}", l_num_updates);
-            println!("table size per pe{}", COUNTS_LOCAL_LEN);
-        }
+    if my_pe == 0 {
+        println!("updates total {}", l_num_updates * num_pes);
+        println!("updates per pe {}", l_num_updates);
+        println!("table size per pe{}", COUNTS_LOCAL_LEN);
+    }
 
     let rand_index = world.alloc_one_sided_mem_region(l_num_updates);
     let mut rng: StdRng = SeedableRng::seed_from_u64(my_pe as u64);
@@ -175,16 +182,13 @@ fn main() {
             "MUPS: {:?}",
             ((l_num_updates * num_pes) as f64 / 1_000_000.0) / global_time
         );
-        println!(
-            "Secs: {:?}",
-             global_time,
-        );
+        println!("Secs: {:?}", global_time,);
         println!(
             "GB/s Injection rate: {:?}",
             (8.0 * (l_num_updates * 2) as f64 * 1.0E-9) / global_time,
         );
     }
-    
+
     if my_pe == 0 {
         println!(
             "{:?} global time {:?} MB {:?} MB/s: {:?} global mups: {:?} ",

--- a/index_gather/src/index_gather_buffered_am.rs
+++ b/index_gather/src/index_gather_buffered_am.rs
@@ -49,7 +49,7 @@ impl LamellarAM for LaunchAm {
                         buff: buff,
                         counts: self.counts.clone(),
                     },
-                );
+                ).await;
                 buffs[rank].clear();
             }
         }
@@ -63,7 +63,7 @@ impl LamellarAM for LaunchAm {
                         buff: buff,
                         counts: self.counts.clone(),
                     },
-                );
+                ).await;
             }
         }
     }
@@ -99,7 +99,7 @@ fn main() {
     let world = lamellar::LamellarWorldBuilder::new().build();
     let my_pe = world.my_pe();
     let num_pes = world.num_pes();
-    let counts = world.alloc_shared_mem_region(COUNTS_LOCAL_LEN);
+    let counts = world.alloc_shared_mem_region(COUNTS_LOCAL_LEN).block();
     let global_count = COUNTS_LOCAL_LEN * num_pes;
     let l_num_updates = args
         .get(1)

--- a/index_gather/src/index_gather_buffered_am.rs
+++ b/index_gather/src/index_gather_buffered_am.rs
@@ -111,12 +111,12 @@ fn main() {
     let l_num_updates = args
         .get(1)
         .and_then(|s| s.parse::<usize>().ok())
-        .unwrap_or_else(|| 1000);
+        .unwrap_or(1000);
 
     let buffer_amt = args
         .get(2)
         .and_then(|s| s.parse::<usize>().ok())
-        .unwrap_or_else(|| 1000);
+        .unwrap_or(1000);
     let num_threads = args
         .get(3)
         .and_then(|s| s.parse::<usize>().ok())

--- a/index_gather/src/index_gather_buffered_am.rs
+++ b/index_gather/src/index_gather_buffered_am.rs
@@ -99,7 +99,7 @@ fn main() {
     let world = lamellar::LamellarWorldBuilder::new().build();
     let my_pe = world.my_pe();
     let num_pes = world.num_pes();
-    let counts = world.alloc_shared_mem_region(COUNTS_LOCAL_LEN).block();
+    let counts = world.alloc_shared_mem_region(COUNTS_LOCAL_LEN);
     let global_count = COUNTS_LOCAL_LEN * num_pes;
     let l_num_updates = args
         .get(1)
@@ -126,6 +126,8 @@ fn main() {
 
     let rand_index = world.alloc_one_sided_mem_region(l_num_updates);
     let mut rng: StdRng = SeedableRng::seed_from_u64(my_pe as u64);
+
+    let counts = counts.block();
 
     unsafe {
         for elem in counts.as_mut_slice().unwrap().iter_mut() {

--- a/index_gather/src/index_gather_read_only_array.rs
+++ b/index_gather/src/index_gather_read_only_array.rs
@@ -5,7 +5,7 @@ use std::time::Instant;
 
 fn index_gather(array: &ReadOnlyArray<usize>, rand_index: OneSidedMemoryRegion<usize>) {
     let rand_slice = unsafe {rand_index.as_slice().expect("PE on world team")}; // Safe as we are the only consumer of this mem region
-    array.batch_load(rand_slice);
+    array.batch_load(rand_slice).block();
 }
 
 const COUNTS_LOCAL_LEN: usize = 1000000; //this will be 800MBB on each pe
@@ -27,7 +27,7 @@ fn main() {
             println!("table size per pe{}", COUNTS_LOCAL_LEN);
         }
 
-    let unsafe_array = UnsafeArray::<usize>::new(world.team(), global_count, lamellar::array::Distribution::Cyclic);
+    let unsafe_array = UnsafeArray::<usize>::new(world.team(), global_count, lamellar::array::Distribution::Cyclic).block();
     let rand_index = world.alloc_one_sided_mem_region(l_num_updates);
     let mut rng: StdRng = SeedableRng::seed_from_u64(my_pe as u64);
 
@@ -43,7 +43,7 @@ fn main() {
         }
     }
     world.block_on(array_init);
-    let array = unsafe_array.into_read_only();
+    let array = unsafe_array.into_read_only().block();
     // let rand_index = rand_index.into_read_only();
     world.barrier();
 

--- a/index_gather/src/index_gather_read_only_array.rs
+++ b/index_gather/src/index_gather_read_only_array.rs
@@ -4,12 +4,12 @@ use rand::prelude::*;
 use std::time::Instant;
 
 fn index_gather(array: &ReadOnlyArray<usize>, rand_index: OneSidedMemoryRegion<usize>) {
-    let rand_slice = unsafe {rand_index.as_slice().expect("PE on world team")}; // Safe as we are the only consumer of this mem region
+    let rand_slice = unsafe { rand_index.as_slice().expect("PE on world team") }; // Safe as we are the only consumer of this mem region
     array.batch_load(rand_slice).block();
 }
 
 const COUNTS_LOCAL_LEN: usize = 1000000; //this will be 800MBB on each pe
-                                             // srun -N <num nodes> target/release/histo_lamellar_array <num updates>
+                                         // srun -N <num nodes> target/release/histo_lamellar_array <num updates>
 fn main() {
     let args: Vec<String> = std::env::args().collect();
     let world = lamellar::LamellarWorldBuilder::new().build();
@@ -21,21 +21,28 @@ fn main() {
         .and_then(|s| s.parse::<usize>().ok())
         .unwrap_or_else(|| 1000);
 
-        if my_pe == 0 {
-            println!("updates total {}", l_num_updates * num_pes);
-            println!("updates per pe {}", l_num_updates);
-            println!("table size per pe{}", COUNTS_LOCAL_LEN);
-        }
+    if my_pe == 0 {
+        println!("updates total {}", l_num_updates * num_pes);
+        println!("updates per pe {}", l_num_updates);
+        println!("table size per pe{}", COUNTS_LOCAL_LEN);
+    }
 
-    let unsafe_array = UnsafeArray::<usize>::new(world.team(), global_count, lamellar::array::Distribution::Cyclic).block();
+    let unsafe_array = UnsafeArray::<usize>::new(
+        world.team(),
+        global_count,
+        lamellar::array::Distribution::Cyclic,
+    )
+    .block();
     let rand_index = world.alloc_one_sided_mem_region(l_num_updates);
     let mut rng: StdRng = SeedableRng::seed_from_u64(my_pe as u64);
 
     // initialize arrays
-    let array_init = unsafe {unsafe_array
-        .dist_iter_mut()
-        .enumerate()
-        .for_each(|(i, x)| *x = i)};
+    let array_init = unsafe {
+        unsafe_array
+            .dist_iter_mut()
+            .enumerate()
+            .for_each(|(i, x)| *x = i)
+    };
     // rand_index.dist_iter_mut().for_each(move |x| *x = rng.lock().gen_range(0,global_count)).wait(); //this is slow because of the lock on the rng so we will do unsafe slice version instead...
     unsafe {
         for elem in rand_index.as_mut_slice().unwrap().iter_mut() {
@@ -78,10 +85,7 @@ fn main() {
             "MUPS: {:?}",
             ((l_num_updates * num_pes) as f64 / 1_000_000.0) / global_time,
         );
-        println!(
-            "Secs: {:?}",
-             global_time,
-        );
+        println!("Secs: {:?}", global_time,);
         println!(
             "GB/s Injection rate: {:?}",
             (8.0 * (l_num_updates * 2) as f64 * 1.0E-9) / global_time,

--- a/index_gather/src/index_gather_read_only_array.rs
+++ b/index_gather/src/index_gather_read_only_array.rs
@@ -19,7 +19,7 @@ fn main() {
     let l_num_updates = args
         .get(1)
         .and_then(|s| s.parse::<usize>().ok())
-        .unwrap_or_else(|| 1000);
+        .unwrap_or(1000);
 
     if my_pe == 0 {
         println!("updates total {}", l_num_updates * num_pes);

--- a/randperm/Cargo.toml
+++ b/randperm/Cargo.toml
@@ -1,19 +1,12 @@
 [package]
 name = "randperm"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Ryan D. Friese"]
 edition = "2021"
 
 [dependencies]
-#serde = { version = "1.0", features = ["derive"] }
-#lazy_static = "1.3.0"
 rand = "0.6"
-lamellar = { version = "0.5.0" } #add features = ["enable-rofi"] to use rofi lamellae
-#parking_lot = { version = "0.12" }
-#tracing = "0.1"
-#tracing-futures = "0.2"
-#tracing-flame = "0.2"
-#tracing-subscriber = "0.3"
+lamellar = { version = "0.7.1" } #add features = ["enable-rofi"] to use rofi lamellae
 
 [profile.release]
 opt-level=3

--- a/randperm/Cargo.toml
+++ b/randperm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "randperm"
-version = "0.2.0"
-authors = ["Ryan D. Friese"]
+version = "0.7.0"
+authors = ["Ryan D. Friese", "Joseph A. Cottam"]
 edition = "2021"
 
 [dependencies]

--- a/randperm/README.md
+++ b/randperm/README.md
@@ -21,7 +21,7 @@ At the time of release, Lamellar has been tested with the following external pac
 
 | **GCC** | **CLANG** | **ROFI**  | **OFI**   | **IB VERBS**  | **MPI**       | **SLURM** | **LAMELLAR** |
 |--------:|----------:|----------:|----------:|--------------:|--------------:|----------:|-------------:|
-| 7.1.0   | 8.0.1     | 0.1.0     | 1.9.0     | 1.13          | mvapich2/2.3a | 17.02.7   | 0.2.1        |
+| 7.1.0   | 8.0.1     | 0.1.0     | 1.9.0     | 1.13          | mvapich2/2.3a | 17.02.7   | 0.7.1        |
 
 The OFI_DIR environment variable must be specified with the location of the OFI installation.
 The ROFI_DIR environment variable must be specified with the location of the ROFI installation.

--- a/randperm/README.md
+++ b/randperm/README.md
@@ -17,12 +17,6 @@ These benchmarks requires the following dependencies:
 
 * Crates listed in Cargo.toml
 
-At the time of release, Lamellar has been tested with the following external packages:
-
-| **GCC** | **CLANG** | **ROFI**  | **OFI**   | **IB VERBS**  | **MPI**       | **SLURM** | **LAMELLAR** |
-|--------:|----------:|----------:|----------:|--------------:|--------------:|----------:|-------------:|
-| 7.1.0   | 8.0.1     | 0.1.0     | 1.9.0     | 1.13          | mvapich2/2.3a | 17.02.7   | 0.7.1        |
-
 The OFI_DIR environment variable must be specified with the location of the OFI installation.
 The ROFI_DIR environment variable must be specified with the location of the ROFI installation.
 
@@ -34,33 +28,27 @@ In the following, assume a root directory ${ROOT}
 0. download Lamellar to ${ROOT}/lamellar-runtime  -- or update Cargo.toml to point to the proper location
     `cd ${ROOT} && git clone https://github.com/pnnl/lamellar-runtime`
 
+
+
 1. cd into registered-am or remote-closure directory and Compile benchmark 
 
 `cargo build (--release)`
-
-    executables located at ./target/debug(release)/<benchmark variant>
-
-    where `<benchmark variant>` in {`histo_dma, histo_static, histo_buffered_updates_dma, histo_buffered_updates_static`}.
 
 
 TESTING
 -------
 The benchmarks are designed to be run with on multiple compute nodes (1 node is valid). Here is a simple proceedure to run the tests that assume a compute cluster and [SLURM](https://slurm.schedmd.com) job manager. Please, refer to the job manager documentaiton for details on how to run command on different clusters. Lamellar grabs job information (size, distribution, etc.) from the jbo manager and runtime launcher (e.g., MPI, please refer to the BUILING REQUIREMENTS section for a list of tested software versions).
 
-1. Allocates two compute nodes on the cluster:
+To run the benchmark through the slurm queue, first compile with `cargo build --release` then run the following:
+- `srun -N 2 target/release/randperm`
 
-`salloc -N 2 -p compute`
-
-2. Run ranperm using `mpiexec` launcher.
-
-`mpiexec -n 2 ./target/release/randperm [size of permuted array] [target array multplier]`
-
-
-Note that if using the "local" lamellae, simply execute the binary directly
+*Note:* If using the "local" lamellae, simply execute the binary directly
 
 
 HISTORY
 -------
+- version 0.7:
+  - Async initialization
 - version 0.1:
   - initial implementation
   

--- a/randperm/src/randperm.rs
+++ b/randperm/src/randperm.rs
@@ -50,9 +50,9 @@ fn main() {
     world.wait_all();
 
     let darts_array = darts_array.into_read_only().block();
+    let target_array = target_array.into_atomic().block();
     let local_darts = darts_array.local_data(); //will use this slice for first iteration
 
-    let target_array = target_array.into_atomic().block();
     world.barrier();
     if my_pe == 0 {
         println!("start");

--- a/randperm/src/randperm.rs
+++ b/randperm/src/randperm.rs
@@ -9,11 +9,11 @@ fn main() {
     let global_count = args
         .get(1)
         .and_then(|s| s.parse::<usize>().ok())
-        .unwrap_or_else(|| 1000); //size of permuted array
+        .unwrap_or(1000); //size of permuted array
     let target_factor = args
         .get(2)
         .and_then(|s| s.parse::<usize>().ok())
-        .unwrap_or_else(|| 10); //multiplication factor for target array
+        .unwrap_or(10); //multiplication factor for target array
 
     if my_pe == 0 {
         println!("array size {}", global_count);
@@ -78,7 +78,7 @@ fn main() {
         .collect::<Vec<usize>>();
 
     // continue launching remaining darts until they all stick
-    while remaining_darts.len() > 0 {
+    while !remaining_darts.is_empty() {
         let rand_index = (0..remaining_darts.len())
             .map(|_| rng.gen_range(0, global_count * target_factor))
             .collect::<Vec<usize>>();

--- a/randperm/src/randperm.rs
+++ b/randperm/src/randperm.rs
@@ -21,7 +21,11 @@ fn main() {
     }
 
     // start with unsafe because they are faster to initialize than AtomicArrays
-    let darts_array = UnsafeArray::<usize>::new(world.team(), global_count, lamellar::array::Distribution::Block);
+    let darts_array = UnsafeArray::<usize>::new(
+        world.team(),
+        global_count,
+        lamellar::array::Distribution::Block,
+    );
     let target_array = UnsafeArray::<usize>::new(
         world.team(),
         global_count * target_factor,
@@ -29,20 +33,26 @@ fn main() {
     );
     let mut rng: StdRng = SeedableRng::seed_from_u64(my_pe as u64);
 
+    //Ensure all arrays finish building...
+    let darts_array = darts_array.block();
+    let target_array = target_array.block();
+
     // initialize arrays
-    let darts_init = unsafe{darts_array
-        .dist_iter_mut()
-        .enumerate()
-        .for_each(|(i, x)| *x = i)}; // each PE some slice in [0..global_count]
-    let target_init = unsafe{target_array.dist_iter_mut().for_each(|x| *x = usize::MAX)};
+    let darts_init = unsafe {
+        darts_array
+            .dist_iter_mut()
+            .enumerate()
+            .for_each(|(i, x)| *x = i)
+    }; // each PE some slice in [0..global_count]
+    let target_init = unsafe { target_array.dist_iter_mut().for_each(|x| *x = usize::MAX) };
     world.block_on(darts_init);
     world.block_on(target_init);
     world.wait_all();
 
-    let darts_array = darts_array.into_read_only();
+    let darts_array = darts_array.into_read_only().block();
     let local_darts = darts_array.local_data(); //will use this slice for first iteration
 
-    let target_array = target_array.into_atomic();
+    let target_array = target_array.into_atomic().block();
     world.barrier();
     if my_pe == 0 {
         println!("start");
@@ -53,8 +63,8 @@ fn main() {
     let rand_index = (0..local_darts.len())
         .map(|_| rng.gen_range(0, global_count * target_factor))
         .collect::<Vec<usize>>();
-      
-    // launch initial set of darts, and collect any that didnt stick    
+
+    // launch initial set of darts, and collect any that didnt stick
     let mut remaining_darts = world
         .block_on(target_array.batch_compare_exchange(&rand_index, usize::MAX, local_darts))
         .iter()
@@ -122,13 +132,16 @@ fn main() {
             (world.MB_sent()) / global_time,
         );
         println!("Secs: {:?}", global_time,);
-        let sum = world.block_on(the_array.sum());
-        println!(
-            "reduced sum: {sum} calculated sum {} ",
-            (global_count * (global_count + 1) / 2) - global_count
-        );
-        if sum != (global_count * (global_count + 1) / 2) - global_count {
-            println!("Error! randperm not as expected");
+        if let Some(sum) = world.block_on(the_array.sum()) {
+            println!(
+                "reduced sum: {sum} calculated sum {} ",
+                (global_count * (global_count + 1) / 2) - global_count
+            );
+            if sum != (global_count * (global_count + 1) / 2) - global_count {
+                println!("Error! randperm not as expected");
+            }
+        } else {
+            println!("Error! randperm computation failed");
         }
     }
 }

--- a/triangle_count/Cargo.toml
+++ b/triangle_count/Cargo.toml
@@ -1,16 +1,15 @@
 [package]
 name = "lamellar_graph"
-version = "0.4.1"
+version = "0.5.0"
 authors = ["frie869 <ryan.friese@pnnl.gov>"]
 edition = "2021"
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 csv = "1"
-lamellar = { version = "0.5.0" } #add features = ["enable-rofi"] to use rofi lamellae
-parking_lot = "0.11"
-async-std = "1.6.4"
+lamellar = { version = "0.7.1" } #add features = ["enable-rofi"] to use rofi lamellae
 bincode = "1.3"
+
 
 [profile.release]
 opt-level=3

--- a/triangle_count/Cargo.toml
+++ b/triangle_count/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "lamellar_graph"
-version = "0.5.0"
-authors = ["frie869 <ryan.friese@pnnl.gov>"]
+version = "0.7.0"
+authors = ["frie869 <ryan.friese@pnnl.gov>", "Joseph A. Cottam"]
 edition = "2021"
 
 [dependencies]

--- a/triangle_count/README.md
+++ b/triangle_count/README.md
@@ -26,12 +26,6 @@ These benchmarks requires the following dependencies:
 
 * Crates listed in Cargo.toml
 
-At the time of release, Lamellar has been tested with the following external packages:
-
-| **GCC** | **CLANG** | **ROFI**  | **OFI**   | **IB VERBS**  | **MPI**       | **SLURM** | **LAMELLAR** |
-|--------:|----------:|----------:|----------:|--------------:|--------------:|----------:|-------------:|
-| 7.1.0   | 8.0.1     | 0.1.0     | 1.9.0     | 1.13          | mvapich2/2.3a | 17.02.7   | 0.2.1        |
-
 The OFI_DIR environment variable must be specified with the location of the OFI installation.
 The ROFI_DIR environment variable must be specified with the location of the ROFI installation.
 
@@ -68,13 +62,11 @@ TESTING
 
 The benchmarks are designed to be run with on multiple compute nodes (1 node is valid). Here is a simple proceedure to run the tests that assume a compute cluster and [SLURM](https://slurm.schedmd.com) job manager. Please, refer to the job manager documentaiton for details on how to run command on different clusters. Lamellar grabs job information (size, distribution, etc.) from the jbo manager and runtime launcher (e.g., MPI, please refer to the BUILING REQUIREMENTS section for a list of tested software versions).
 
-1. Unzip the data file `./input_graphs/graph500-scale18-ef16_adj.tsv.tar.gz`
-2. Allocate two compute nodes on the cluster:
+Before running any benchmarks, unzip the data file `./input_graphs/graph500-scale18-ef16_adj.tsv.tar.gz`
 
-`salloc -N 2 -p compute`
-3. Run triangle_count(_buffered) using `mpiexec` launcher.
-
-`mpiexec -n 2 ./target/release/triangle_count(_buffered) ./input_graphs/graph500-scale18-ef16_adj.tsv`  (argument = number of launcher threads/tasks)
+To run the benchmark through the slurm queue, first compile with `cargo build --release` then run one of the following:
+- `srun -N 2 target/release/triangle_count input_graphs/graph500-scale18-ef16_adj.tsv`
+- `srun -N 2 target/release/triangle_count_buffered input_graphs/graph500-scale18-ef16_adj.tsv`
 
 GRAPHS
 ------

--- a/triangle_count/src/lib.rs
+++ b/triangle_count/src/lib.rs
@@ -425,7 +425,8 @@ impl Graph {
                     .exec_am_local(RelabelAm {
                         nodes: temp_nodes,
                         relabeled: relabeled.clone(),
-                    }).spawn();
+                    })
+                    .spawn();
                 temp_nodes = vec![];
                 size = 0;
             }
@@ -441,7 +442,8 @@ impl Graph {
                 .exec_am_local(RelabelAm {
                     nodes: temp_nodes,
                     relabeled: relabeled.clone(),
-                }).spawn();
+                })
+                .spawn();
         }
         println!("reorder issue time: {:?}", start.elapsed().as_secs_f64());
         world.wait_all();
@@ -475,7 +477,8 @@ impl Graph {
                             node_and_neighbors: neigh_lists
                                 .split_off(neigh_lists.len() - batch_size),
                         },
-                    ).spawn();
+                    )
+                    .spawn();
             }
             if neigh_lists.len() > 0 {
                 let _ = task_group
@@ -485,7 +488,8 @@ impl Graph {
                             graph: graph.clone(),
                             node_and_neighbors: neigh_lists.clone(),
                         },
-                    ).spawn();
+                    )
+                    .spawn();
             }
         }
 

--- a/triangle_count/src/lib.rs
+++ b/triangle_count/src/lib.rs
@@ -193,7 +193,7 @@ struct RelabelAm {
 #[lamellar::local_am]
 impl LamellarAM for RelabelAm {
     async fn exec() {
-        let relabled = unsafe {self.relabeled.as_slice().unwrap()};
+        let relabled = unsafe { self.relabeled.as_slice().unwrap() };
         for nodes in &self.nodes {
             let old_nodes = &nodes.0;
             let new_nodes = unsafe { nodes.1.as_mut_slice().unwrap() };
@@ -219,15 +219,17 @@ struct LocalNeighborsAM {
 #[lamellar::am]
 impl LamellarAM for LocalNeighborsAM {
     async fn exec() {
-        let mut graph = self.graph.write();
+        let mut graph = self.graph.write().await;
         let mut remotes: Vec<(u32, OneSidedMemoryRegion<u32>)> = vec![];
         for (node, neighbors) in &self.node_and_neighbors {
             remotes.push((*node, graph.add_local_neighbors(*node, neighbors.clone())));
         }
-        lamellar::world.exec_am_all(RemoteNeighborsAM {
-            graph: self.graph.clone(),
-            node_and_neighbors: remotes,
-        });
+        lamellar::world
+            .exec_am_all(RemoteNeighborsAM {
+                graph: self.graph.clone(),
+                node_and_neighbors: remotes,
+            })
+            .await;
     }
 }
 
@@ -239,7 +241,7 @@ struct RemoteNeighborsAM {
 #[lamellar::am]
 impl LamellarAM for RemoteNeighborsAM {
     async fn exec() {
-        let mut graph = self.graph.write();
+        let mut graph = self.graph.write().await;
         for (node, neighbors) in &self.node_and_neighbors {
             graph.add_remote_neighbors(*node, neighbors.clone());
         }
@@ -259,7 +261,9 @@ impl Graph {
         let graph = match graph_type {
             _map_graph => GraphData::MapGraph(MapGraph::new(world.team().clone())),
         };
-        let graph = LocalRwDarc::new(world.team(), graph).unwrap(); // we are creating with the world team so should be valid on all pes
+
+        // TODO: Should new be made async to 'await' instead?
+        let graph = LocalRwDarc::new(world.team(), graph).block().unwrap(); // we are creating with the world team so should be valid on all pes
 
         Graph::load(fpath, &world, &graph).expect("error reading graph");
         if my_pe == 0 {
@@ -267,7 +271,8 @@ impl Graph {
         }
         let g = Graph {
             world: world,
-            graph: graph.into_darc(),
+            graph: graph.into_darc().block(), // TODO: Should new be made async to 'await' instead?
+
             my_pe: my_pe,
         };
         if my_pe == 0 {
@@ -415,10 +420,12 @@ impl Graph {
         let mut i = 0;
         for nodes in temp_neighbor_list.drain(..) {
             if size > num_edges / 10 {
-                world.exec_am_local(RelabelAm {
-                    nodes: temp_nodes,
-                    relabeled: relabeled.clone(),
-                });
+                world
+                    .exec_am_local(RelabelAm {
+                        nodes: temp_nodes,
+                        relabeled: relabeled.clone(),
+                    })
+                    .block();
                 temp_nodes = vec![];
                 size = 0;
             }
@@ -430,22 +437,25 @@ impl Graph {
             i += 1;
         }
         if size > 0 {
-            world.exec_am_local(RelabelAm {
-                nodes: temp_nodes,
-                relabeled: relabeled.clone(),
-            });
+            world
+                .exec_am_local(RelabelAm {
+                    nodes: temp_nodes,
+                    relabeled: relabeled.clone(),
+                })
+                .block();
         }
         println!("reorder issue time: {:?}", start.elapsed().as_secs_f64());
         world.wait_all();
         println!("reorder  time: {:?}", start.elapsed().as_secs_f64());
 
         let task_group = LamellarTaskGroup::new(world.team());
-        let mut pe_neigh_lists: HashMap<usize, Vec<(u32, OneSidedMemoryRegion<u32>)>> = HashMap::new();
+        let mut pe_neigh_lists: HashMap<usize, Vec<(u32, OneSidedMemoryRegion<u32>)>> =
+            HashMap::new();
         for pe in 0..world.num_pes() {
             pe_neigh_lists.insert(pe, vec![]);
         }
         for old_node in 0..neigh_list.len() {
-            let new_node = unsafe{relabeled.as_slice().unwrap()[old_node] as usize};
+            let new_node = unsafe { relabeled.as_slice().unwrap()[old_node] as usize };
             let pe = new_node % world.num_pes();
             pe_neigh_lists
                 .get_mut(&pe)
@@ -458,22 +468,27 @@ impl Graph {
             let batch_size = neigh_lists.len() / 10;
 
             while neigh_lists.len() > batch_size {
-                task_group.exec_am_pe(
-                    *pe,
-                    LocalNeighborsAM {
-                        graph: graph.clone(),
-                        node_and_neighbors: neigh_lists.split_off(neigh_lists.len() - batch_size),
-                    },
-                );
+                task_group
+                    .exec_am_pe(
+                        *pe,
+                        LocalNeighborsAM {
+                            graph: graph.clone(),
+                            node_and_neighbors: neigh_lists
+                                .split_off(neigh_lists.len() - batch_size),
+                        },
+                    )
+                    .block();
             }
             if neigh_lists.len() > 0 {
-                task_group.exec_am_pe(
-                    *pe,
-                    LocalNeighborsAM {
-                        graph: graph.clone(),
-                        node_and_neighbors: neigh_lists.clone(),
-                    },
-                );
+                task_group
+                    .exec_am_pe(
+                        *pe,
+                        LocalNeighborsAM {
+                            graph: graph.clone(),
+                            node_and_neighbors: neigh_lists.clone(),
+                        },
+                    )
+                    .block();
             }
         }
         println!("distribute issue time: {:?}", start.elapsed().as_secs_f64());

--- a/triangle_count/src/mapgraph.rs
+++ b/triangle_count/src/mapgraph.rs
@@ -1,9 +1,6 @@
-// use csv;
 use lamellar::memregion::prelude::*;
 use std::collections::HashMap;
 use std::sync::Arc;
-
-// use parking_lot::RwLock;
 
 use crate::GraphOps;
 // use crate::Element;
@@ -71,7 +68,7 @@ impl GraphOps for MapGraph {
     }
     fn neighbors(&self, node: &u32) -> std::slice::Iter<'_, u32> {
         if let Some(n) = self.neighbors.get(node) {
-            match unsafe {n.as_slice()} {
+            match unsafe { n.as_slice() } {
                 Ok(n) => n.iter(),
                 Err(_) => panic!(
                     "node {:?} is not local to pe {:?}",

--- a/triangle_count/src/triangle_count.rs
+++ b/triangle_count/src/triangle_count.rs
@@ -32,16 +32,18 @@ impl LamellarAM for LaunchAm {
         let task_group = LamellarTaskGroup::new(lamellar::world.clone());
         let graph_data = self.graph.data();
         for node_0 in (self.start..self.end).filter(|n| self.graph.node_is_local(n)) {
-            task_group.exec_am_all(TcAm {
-                graph: graph_data.clone(),
-                node: node_0,
-                neighbors: graph_data
-                    .neighbors_iter(&node_0)
-                    .take_while(|n| n < &&node_0)
-                    .map(|n| *n)
-                    .collect::<Vec<u32>>(), //only send neighbors that are less than node_0 as an optimization
-                final_cnt: self.final_cnt.clone(),
-            });
+            task_group
+                .exec_am_all(TcAm {
+                    graph: graph_data.clone(),
+                    node: node_0,
+                    neighbors: graph_data
+                        .neighbors_iter(&node_0)
+                        .take_while(|n| n < &&node_0)
+                        .map(|n| *n)
+                        .collect::<Vec<u32>>(), //only send neighbors that are less than node_0 as an optimization
+                    final_cnt: self.final_cnt.clone(),
+                })
+                .await;
         }
     }
 }
@@ -115,7 +117,7 @@ fn main() {
     //this loads, reorders, and distributes the graph to all PEs
     let graph: Graph = Graph::new(file, GraphType::MapGraph, world.clone());
     graph.dump_to_bin(&format!("{file}.bin"));
-    let final_cnt = Darc::new(&world, AtomicUsize::new(0)).unwrap(); // initialize our local counter (which is accessible to all PEs)
+    let final_cnt = Darc::new(&world, AtomicUsize::new(0)).block().unwrap(); // initialize our local counter (which is accessible to all PEs)
 
     if my_pe == 0 {
         println!("num nodes {:?}", graph.num_nodes())

--- a/triangle_count/src/triangle_count.rs
+++ b/triangle_count/src/triangle_count.rs
@@ -42,7 +42,8 @@ impl LamellarAM for LaunchAm {
                         .map(|n| *n)
                         .collect::<Vec<u32>>(), //only send neighbors that are less than node_0 as an optimization
                     final_cnt: self.final_cnt.clone(),
-                }).spawn();
+                })
+                .spawn();
         }
         task_group.await_all().await;
     }

--- a/triangle_count/src/triangle_count.rs
+++ b/triangle_count/src/triangle_count.rs
@@ -32,7 +32,7 @@ impl LamellarAM for LaunchAm {
         let task_group = LamellarTaskGroup::new(lamellar::world.clone());
         let graph_data = self.graph.data();
         for node_0 in (self.start..self.end).filter(|n| self.graph.node_is_local(n)) {
-            task_group
+            let _ = task_group
                 .exec_am_all(TcAm {
                     graph: graph_data.clone(),
                     node: node_0,
@@ -42,9 +42,9 @@ impl LamellarAM for LaunchAm {
                         .map(|n| *n)
                         .collect::<Vec<u32>>(), //only send neighbors that are less than node_0 as an optimization
                     final_cnt: self.final_cnt.clone(),
-                })
-                .await;
+                }).spawn();
         }
+        task_group.await_all().await;
     }
 }
 

--- a/triangle_count/src/triangle_count_buffered.rs
+++ b/triangle_count/src/triangle_count_buffered.rs
@@ -33,7 +33,8 @@ impl LamellarAM for LaunchAm {
                         graph: graph_data.clone(),
                         data: buffer,
                         final_cnt: self.final_cnt.clone(),
-                    }).spawn();
+                    })
+                    .spawn();
                 buffer = vec![];
                 cur_len = 0;
             }
@@ -45,7 +46,8 @@ impl LamellarAM for LaunchAm {
                     graph: graph_data.clone(),
                     data: buffer,
                     final_cnt: self.final_cnt.clone(),
-                }).spawn();
+                })
+                .spawn();
         }
         task_group.await_all().await;
     }
@@ -138,13 +140,15 @@ fn main() {
             let start = (tid as f32 * batch_size).round() as u32;
             let end = ((tid + 1) as f32 * batch_size).round() as u32;
             reqs.push(
-                world.exec_am_local(LaunchAm {
-                    graph: graph.clone(),
-                    start: start,
-                    end: end,
-                    final_cnt: final_cnt.clone(),
-                    buf_size: *buf_size,
-                }).spawn()
+                world
+                    .exec_am_local(LaunchAm {
+                        graph: graph.clone(),
+                        start: start,
+                        end: end,
+                        final_cnt: final_cnt.clone(),
+                        buf_size: *buf_size,
+                    })
+                    .spawn(),
             );
         }
 


### PR DESCRIPTION
The transition from 0.5 to 0.7 included many calls returning "handles" instead of the expected result.  This exposes more opportunities for concurrent execution, but also requires calls to spawn/await/block to ensure the concurrent tasks are completed.  

This update to the benchmarks takes advantage of these capabilities in 0.7 **without** changing the fundamental algorithms.  

All benchmarks compile and run to completion in both debug and release configurations.

Results were **not** exhaustively check for correctness, though some simple checks were done (e.g., both versions of triangle count return the same value).