### PR TITLE
Atomic histo deadlock fix

### DIFF
--- a/histo/src/histo_lamellar_array_comparison.rs
+++ b/histo/src/histo_lamellar_array_comparison.rs
@@ -82,7 +82,7 @@ fn main() {
     let counts = counts.block();
 
     // initialize arrays
-    let counts_init = unsafe { counts.dist_iter_mut().for_each(|x| *x = 0) };
+    let counts_init = unsafe { counts.dist_iter_mut().for_each(|x| *x = 0).spawn() };
     // rand_index.dist_iter_mut().for_each(move |x| *x = rng.lock().gen_range(0,global_count)).wait(); //this is slow because of the lock on the rng so we will do unsafe slice version instead...
     let rand_index = rand_index.block();
 
@@ -112,7 +112,7 @@ fn main() {
         1,
         0.0,
     );
-    world.block_on(unsafe { counts.dist_iter_mut().for_each(|x| *x = 0) });
+    world.block_on(unsafe { counts.dist_iter_mut().for_each(|x| *x = 0).spawn() });
     counts.barrier();
 
     let counts = counts.into_local_lock().block();

--- a/histo/src/histo_lamellar_atomicarray.rs
+++ b/histo/src/histo_lamellar_atomicarray.rs
@@ -49,7 +49,7 @@ fn main() {
     let unsafe_counts = unsafe_counts.block();
 
     // initialize arrays
-    let counts_init = unsafe { unsafe_counts.dist_iter_mut().for_each(|x| *x = 0) };
+    let counts_init = unsafe { unsafe_counts.dist_iter_mut().for_each(|x| *x = 0).spawn() };
     // rand_index.dist_iter_mut().for_each(move |x| *x = rng.lock().gen_range(0,global_count)).wait(); //this is slow because of the lock on the rng so we will do unsafe slice version instead...
 
     let rand_index = rand_index.block();


### PR DESCRIPTION
Some spawns were missing from the upgrade to 0.7.1.  Without them, these benchmarks deadlocked in some configurations.